### PR TITLE
add libxcrypt: glibc-2.39 depends on this now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ OPENSSL_VERSION ?= 3.0.7-r0
 READLINE_VERSION ?= 8.1.2-r0
 SQLITE_VERSION ?= 3.39.2-r0
 PYTHON3_VERSION ?= 3.10.6-r0
+LIBXCRYPT_VERSION ?= 4.4.36-r0
 GLIBC_VERSION ?= 2.36-r0
 BUSYBOX_VERSION ?= 1.35.0-r2
 CA_CERTIFICATES_VERSION ?= 20220614-r1
@@ -90,6 +91,7 @@ PACKAGES = \
 	packages/${ARCH}/readline-${READLINE_VERSION}.apk \
 	packages/${ARCH}/sqlite-${SQLITE_VERSION}.apk \
 	packages/${ARCH}/python3-${PYTHON3_VERSION}.apk \
+	packages/${ARCH}/libxcrypt-${LIBXCRYPT_VERSION}.apk \
 	packages/${ARCH}/glibc-${GLIBC_VERSION}.apk \
 	packages/${ARCH}/busybox-${BUSYBOX_VERSION}.apk \
 	packages/${ARCH}/ca-certificates-${CA_CERTIFICATES_VERSION}.apk \
@@ -195,6 +197,9 @@ packages/${ARCH}/sqlite-${SQLITE_VERSION}.apk:
 
 packages/${ARCH}/python3-${PYTHON3_VERSION}.apk:
 	${MELANGE} build python3.yaml ${MELANGE_OPTS} ${MELANGE_DEFOPTS}
+
+packages/${ARCH}/libxcrypt-${LIBXCRYPT_VERSION}.apk:
+    ${MELANGE} build libxcrypt.yaml ${MELANGE_OPTS} ${MELANGE_DEFOPTS}
 
 packages/${ARCH}/glibc-${GLIBC_VERSION}.apk:
 	${MELANGE} build glibc.yaml ${MELANGE_OPTS} --source-dir ./glibc/

--- a/libxcrypt.yaml
+++ b/libxcrypt.yaml
@@ -1,0 +1,68 @@
+package:
+  name: libxcrypt
+  version: 4.4.36
+  epoch: 0
+  description: "Modern library for one-way hashing of passwords"
+  copyright:
+    - license: GPL-2.0-or-later AND LGPL-2.1-or-later
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/bootstrap/stage2
+    keyring:
+      - https://packages.wolfi.dev/bootstrap/stage2/wolfi-signing.rsa.pub
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gettext
+      - libtool
+      - pkgconf
+      - wolfi-baselayout
+
+pipeline:
+  # Using Fetch instead of git checkout
+  # @kaniini : When we retire libcrypt from glibc, it will need to get built earlier than git, as git (indirectly) depends on libcrypt.
+  - uses: fetch
+    with:
+      uri: https://github.com/besser82/libxcrypt/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-sha256: b979838d5f1f238869d467484793b72b8bca64c4eae696fdbba0a9e0b6c28453
+
+  - runs: |
+      ./autogen.sh
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --prefix=/usr \
+        --disable-static \
+        --enable-hashes=strong,glibc \
+        --enable-obsolete-api=no \
+        --disable-failure-tokens
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: libxcrypt-doc
+    pipeline:
+      - uses: split/manpages
+    description: libxcrypt manpages
+
+  - name: libxcrypt-dev
+    pipeline:
+      - uses: split/dev
+    description: libxcrypt dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 16436


### PR DESCRIPTION
Related to glibc upgrade  https://github.com/wolfi-dev/os/pull/12226/
As the CI doesn't run on each PR 

```
getting package dir for ./libxcrypt.yaml
For package pkgdir found dir: .
found package dir as .
getting source dir for package libxcrypt with dir .
+ '[[' . '==' . ]]
+ echo '--source-dir ./libxcrypt'
found source dir as --source-dir ./libxcrypt
yamlfile is ./libxcrypt.yaml
Building package libxcrypt with version libxcrypt-4.4.36-r0 from file ./libxcrypt.yaml
make yamlfile=./libxcrypt.yaml srcdirflag="--source-dir ./libxcrypt" pkgname=libxcrypt packages/x86_64/libxcrypt-4.4.36-r0.apk
make[1]: Entering directory '/work/work'
fatal: detected dubious ownership in repository at '/work/work'
To add an exception for this directory, call:

	git config --global --add safe.directory /work/work
2024/02/21 20:23:57 INFO melange is building:
2024/02/21 20:23:57 INFO   configuration file: ./libxcrypt.yaml
2024/02/21 20:23:57 INFO   workspace dir: /tmp/melange-workspace-66114320
2024/02/21 20:23:57 INFO evaluating pipelines for package requirements
2024/02/21 20:23:57 INFO   adding packages [wget] for pipeline "Fetch and extract external object into workspace"
2024/02/21 20:23:57 INFO   adding packages [make] for pipeline "Run autoconf make"
2024/02/21 20:23:57 INFO   adding packages [make] for pipeline "Run autoconf make install"
2024/02/21 20:23:57 INFO   adding packages [binutils scanelf] for pipeline "Strip binaries"
2024/02/21 20:23:57 INFO populating workspace /tmp/melange-workspace-66114320 from ./libxcrypt
2024/02/21 20:23:57 INFO --cache-dir ./melange-cache/ not a dir; skipping
2024/02/21 20:23:57 INFO building workspace in '/tmp/melange-guest-642966201' with apko
2024/02/21 20:23:57 INFO image configuration:
2024/02/21 20:23:57 INFO   contents:
2024/02/21 20:23:57 INFO     repositories: [https://packages.wolfi.dev/bootstrap/stage2]
2024/02/21 20:23:57 INFO     keyring:      [https://packages.wolfi.dev/bootstrap/stage2/wolfi-signing.rsa.pub]
2024/02/21 20:23:57 INFO     packages:     [autoconf automake binutils build-base busybox ca-certificates-bundle gettext libtool make pkgconf scanelf wget wolfi-baselayout]
2024/02/21 20:23:57 INFO   accounts:
2024/02/21 20:23:57 INFO     runas:  
2024/02/21 20:23:57 INFO     users:
2024/02/21 20:23:57 INFO       - uid=1000(build) gid=1000
2024/02/21 20:23:57 INFO     groups:
2024/02/21 20:23:57 INFO       - gid=1000(build) members=[build]
2024/02/21 20:24:01 INFO creating group 1000(build)
2024/02/21 20:24:03 INFO built image layer tarball as /tmp/apko-temp-1070836247/apko-x86_64.tar.gz
2024/02/21 20:24:03 INFO using /tmp/apko-temp-1070836247/apko-x86_64.tar.gz for image layer
2024/02/21 20:24:06 INFO ImgRef = /tmp/melange-guest-4074152788
2024/02/21 20:24:06 INFO executing: bwrap --bind /tmp/melange-guest-4074152788 / --bind /tmp/melange-workspace-66114320 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv SOURCE_DATE_EPOCH 0 --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv GOFLAGS  --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap --setenv HOME /home/build --setenv GOPATH /home/build/.cache/go --setenv GOTOOLCHAIN local --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell /bin/sh -c [ -x /sbin/ldconfig ] && /sbin/ldconfig /lib || true
2024/02/21 20:24:06 INFO running step "fetch"
2024/02/21 20:24:06 INFO running step "Fetch and extract external object into workspace"
2024/02/21 20:24:06 INFO executing: bwrap --bind /tmp/melange-guest-4074152788 / --bind /tmp/melange-workspace-66114320 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv GOPATH /home/build/.cache/go --setenv GOTOOLCHAIN local --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap --setenv HOME /home/build --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv SOURCE_DATE_EPOCH 0 --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv GOFLAGS  /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
if [ "b979838d5f1f238869d467484793b72b8bca64c4eae696fdbba0a9e0b6c28453" == "" ] && [ "" == "" ]; then
  printf "One of expected-sha256 or expected-sha512 is required"
  exit 1
fi

bn=$(basename https://github.com/besser82/libxcrypt/archive/refs/tags/v4.4.36.tar.gz)

if [ ! "b979838d5f1f238869d467484793b72b8bca64c4eae696fdbba0a9e0b6c28453" == "" ]; then
  fn="/var/cache/melange/sha256:b979838d5f1f238869d467484793b72b8bca64c4eae696fdbba0a9e0b6c28453"
  if [ -f $fn ]; then
    printf "fetch: found $fn in cache\n"
    cp $fn $bn
  fi
else
  fn="/var/cache/melange/sha512:"
  if [ -f $fn ]; then
    printf "fetch: found $fn in cache\n"
    cp $fn $bn
  fi
fi

if [ ! -f $bn ]; then
  wget '-T5' '--dns-timeout=20' '--tries=5' --random-wait --retry-connrefused --continue 'https://github.com/besser82/libxcrypt/archive/refs/tags/v4.4.36.tar.gz'
fi

if [ "b979838d5f1f238869d467484793b72b8bca64c4eae696fdbba0a9e0b6c28453" != "" ]; then
  printf "%s  %s\n" 'b979838d5f1f238869d467484793b72b8bca64c4eae696fdbba0a9e0b6c28453' $bn | sha256sum -c
else
  printf "%s  %s\n" '' $bn | sha512sum -c
fi

if [ "true" = "true" ]; then
  tar -x '--strip-components=1' -f $bn
fi

if [ "false" = "true" ]; then
  rm $bn
fi

exit 0
2024/02/21 20:24:06 WARN --2024-02-21 20:24:06--  https://github.com/besser82/libxcrypt/archive/refs/tags/v4.4.36.tar.gz
2024/02/21 20:24:06 WARN Resolving github.com... 140.82.113.4
2024/02/21 20:24:07 WARN Connecting to github.com|140.82.113.4|:443... connected.
2024/02/21 20:24:07 WARN HTTP request sent, awaiting response... 302 Found
2024/02/21 20:24:07 WARN Location: https://codeload.github.com/besser82/libxcrypt/tar.gz/refs/tags/v4.4.36 [following]
2024/02/21 20:24:07 WARN --2024-02-21 20:24:07--  https://codeload.github.com/besser82/libxcrypt/tar.gz/refs/tags/v4.4.36
2024/02/21 20:24:07 WARN Resolving codeload.github.com... 140.82.113.9
2024/02/21 20:24:07 WARN Connecting to codeload.github.com|140.82.113.9|:443... connected.
2024/02/21 20:24:07 WARN HTTP request sent, awaiting response... 200 OK
2024/02/21 20:24:07 WARN Length: unspecified [application/x-gzip]
2024/02/21 20:24:07 WARN Saving to: 'v4.4.36.tar.gz'
2024/02/21 20:24:07 WARN
2024/02/21 20:24:07 WARN      0K .......... .......... .......... .......... .......... 1.02M
2024/02/21 20:24:07 WARN     50K .......... .......... .......... .......... .......... 2.03M
2024/02/21 20:24:07 WARN    100K .......... .......... .......... .......... ..........  108M
2024/02/21 20:24:07 WARN    150K .......... .......... .......... .......... .......... 2.08M
2024/02/21 20:24:07 WARN    200K .......... .......... .......... .......... ..........  141M
2024/02/21 20:24:07 WARN    250K .......... .......... .......... .......... ..........  143M
2024/02/21 20:24:07 WARN    300K .......... .......... .......... .......... .......... 2.09M
2024/02/21 20:24:07 WARN    350K .......... .......... .......... .......... ..........  151M
2024/02/21 20:24:07 WARN    400K .......... .......... .......... .......... ..........  129M
2024/02/21 20:24:07 WARN    450K .......... .......... .......... .......... ..........  133M
2024/02/21 20:24:07 WARN    500K .......... ......                                       136M=0.1s
2024/02/21 20:24:07 WARN
2024/02/21 20:24:07 WARN 2024-02-21 20:24:07 (4.17 MB/s) - 'v4.4.36.tar.gz' saved [528595]
2024/02/21 20:24:07 WARN
2024/02/21 20:24:07 INFO v4.4.36.tar.gz: OK
2024/02/21 20:24:07 INFO executing: bwrap --bind /tmp/melange-guest-4074152788 / --bind /tmp/melange-workspace-66114320 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap --setenv HOME /home/build --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv SOURCE_DATE_EPOCH 0 --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv GOFLAGS  --setenv GOPATH /home/build/.cache/go --setenv GOTOOLCHAIN local --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
./autogen.sh

exit 0
2024/02/21 20:24:07 INFO autogen: running: autoreconf -fiv -Wall,error
2024/02/21 20:24:07 WARN autoreconf: export WARNINGS=all,error
2024/02/21 20:24:07 WARN autoreconf: Entering directory '.'
2024/02/21 20:24:07 WARN autoreconf: configure.ac: not using Gettext
2024/02/21 20:24:08 WARN autoreconf: running: aclocal --force -I build-aux/m4
2024/02/21 20:24:09 WARN autoreconf: configure.ac: tracing
2024/02/21 20:24:09 WARN autoreconf: running: libtoolize --copy --force
2024/02/21 20:24:09 INFO libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux/m4-autogen'.
2024/02/21 20:24:09 INFO libtoolize: copying file 'build-aux/m4-autogen/ltmain.sh'
2024/02/21 20:24:09 INFO libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'build-aux/m4'.
2024/02/21 20:24:09 INFO libtoolize: copying file 'build-aux/m4/libtool.m4'
2024/02/21 20:24:09 INFO libtoolize: copying file 'build-aux/m4/ltoptions.m4'
2024/02/21 20:24:09 INFO libtoolize: copying file 'build-aux/m4/ltsugar.m4'
2024/02/21 20:24:09 INFO libtoolize: copying file 'build-aux/m4/ltversion.m4'
2024/02/21 20:24:09 INFO libtoolize: copying file 'build-aux/m4/lt~obsolete.m4'
2024/02/21 20:24:09 WARN autoreconf: configure.ac: not using Intltool
2024/02/21 20:24:09 WARN autoreconf: configure.ac: not using Gtkdoc
2024/02/21 20:24:09 WARN autoreconf: running: aclocal --force -I build-aux/m4
2024/02/21 20:24:10 WARN autoreconf: running: /usr/bin/autoconf --force
2024/02/21 20:24:10 WARN autoreconf: running: /usr/bin/autoheader --force
2024/02/21 20:24:11 WARN autoreconf: running: automake --add-missing --copy --force-missing
2024/02/21 20:24:11 WARN configure.ac:30: installing 'build-aux/m4-autogen/compile'
2024/02/21 20:24:11 WARN configure.ac:29: installing 'build-aux/m4-autogen/config.guess'
2024/02/21 20:24:11 WARN configure.ac:29: installing 'build-aux/m4-autogen/config.sub'
2024/02/21 20:24:11 WARN configure.ac:16: installing 'build-aux/m4-autogen/install-sh'
2024/02/21 20:24:11 WARN configure.ac:16: installing 'build-aux/m4-autogen/missing'
2024/02/21 20:24:11 WARN Makefile.am: installing './INSTALL'
2024/02/21 20:24:11 WARN Makefile.am: installing 'build-aux/m4-autogen/depcomp'
2024/02/21 20:24:11 WARN parallel-tests: installing 'build-aux/m4-autogen/test-driver'
2024/02/21 20:24:11 WARN autoreconf: 'build-aux/m4-autogen/install-sh' is updated
2024/02/21 20:24:11 WARN autoreconf: 'build-aux/m4-autogen/config.sub' is updated
2024/02/21 20:24:11 WARN autoreconf: 'build-aux/m4-autogen/config.guess' is updated
2024/02/21 20:24:11 WARN autoreconf: Leaving directory '.'
2024/02/21 20:24:11 INFO running step "autoconf/configure"
2024/02/21 20:24:11 INFO running step "Run autoconf configure script"
2024/02/21 20:24:11 INFO executing: bwrap --bind /tmp/melange-guest-4074152788 / --bind /tmp/melange-workspace-66114320 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv GOPATH /home/build/.cache/go --setenv GOTOOLCHAIN local --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv SOURCE_DATE_EPOCH 0 --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv GOFLAGS  --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap --setenv HOME /home/build --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
cd .
./configure \
  --host=x86_64-pc-linux-gnu \
  --build=x86_64-pc-linux-gnu \
  --prefix=/usr \
  --sysconfdir=/etc \
  --libdir=/usr/lib \
  --mandir=/usr/share/man \
  --infodir=/usr/share/info \
  --localstatedir=/var \
  --prefix=/usr \
--disable-static \
--enable-hashes=strong,glibc \
--enable-obsolete-api=no \
--disable-failure-tokens


exit 0
2024/02/21 20:24:11 INFO checking for a BSD-compatible install... /usr/bin/install -c
2024/02/21 20:24:11 INFO checking whether build environment is sane... yes
2024/02/21 20:24:11 INFO checking for a race-free mkdir -p... /bin/mkdir -p
2024/02/21 20:24:11 INFO checking for gawk... no
2024/02/21 20:24:11 INFO checking for mawk... no
2024/02/21 20:24:11 INFO checking for nawk... no
2024/02/21 20:24:11 INFO checking for awk... awk
2024/02/21 20:24:11 INFO checking whether make sets $(MAKE)... yes
2024/02/21 20:24:11 INFO checking whether make supports nested variables... yes
2024/02/21 20:24:11 INFO checking build system type... x86_64-pc-linux-gnu
2024/02/21 20:24:11 INFO checking host system type... x86_64-pc-linux-gnu
2024/02/21 20:24:11 INFO checking for x86_64-pc-linux-gnu-gcc... x86_64-pc-linux-gnu-gcc
2024/02/21 20:24:11 INFO checking whether the C compiler works... yes
2024/02/21 20:24:11 INFO checking for C compiler default output file name... a.out
2024/02/21 20:24:11 INFO checking for suffix of executables... 
2024/02/21 20:24:11 INFO checking whether we are cross compiling... no
2024/02/21 20:24:11 INFO checking for suffix of object files... o
2024/02/21 20:24:11 INFO checking whether the compiler supports GNU C... yes
2024/02/21 20:24:11 INFO checking whether x86_64-pc-linux-gnu-gcc accepts -g... yes
2024/02/21 20:24:12 INFO checking for x86_64-pc-linux-gnu-gcc option to enable C11 features... none needed
2024/02/21 20:24:12 INFO checking whether x86_64-pc-linux-gnu-gcc understands -c and -o together... yes
2024/02/21 20:24:12 INFO checking whether make supports the include directive... yes (GNU style)
2024/02/21 20:24:12 INFO checking dependency style of x86_64-pc-linux-gnu-gcc... gcc3
2024/02/21 20:24:12 WARN ./configure: line 4760: PKG_PROG_PKG_CONFIG: not found
2024/02/21 20:24:12 WARN ./configure: line 4761: --atleast-pkgconfig-version: not found
2024/02/21 20:24:12 INFO checking how to run the C preprocessor... x86_64-pc-linux-gnu-gcc -E
2024/02/21 20:24:12 INFO checking whether make sets $(MAKE)... (cached) yes
2024/02/21 20:24:12 INFO checking whether ln -s works... yes
2024/02/21 20:24:12 INFO checking for perl... /usr/bin/perl
2024/02/21 20:24:12 INFO checking whether /usr/bin/perl is version 5.14.0 or later... yes
2024/02/21 20:24:12 INFO checking for gpg2... false
2024/02/21 20:24:12 INFO checking for sha256sum... /usr/bin/sha256sum
2024/02/21 20:24:12 INFO checking for stdio.h... yes
2024/02/21 20:24:12 INFO checking for stdlib.h... yes
2024/02/21 20:24:12 INFO checking for string.h... yes
2024/02/21 20:24:12 INFO checking for inttypes.h... yes
2024/02/21 20:24:12 INFO checking for stdint.h... yes
2024/02/21 20:24:12 INFO checking for strings.h... yes
2024/02/21 20:24:12 INFO checking for sys/stat.h... yes
2024/02/21 20:24:12 INFO checking for sys/types.h... yes
2024/02/21 20:24:12 INFO checking for unistd.h... yes
2024/02/21 20:24:12 INFO checking for wchar.h... yes
2024/02/21 20:24:12 INFO checking for minix/config.h... no
2024/02/21 20:24:12 INFO checking for fcntl.h... yes
2024/02/21 20:24:12 INFO checking for stdbool.h... yes
2024/02/21 20:24:12 INFO checking for ucontext.h... yes
2024/02/21 20:24:12 INFO checking for sys/cdefs.h... yes
2024/02/21 20:24:12 INFO checking for sys/random.h... yes
2024/02/21 20:24:12 INFO checking for sys/syscall.h... yes
2024/02/21 20:24:12 INFO checking for valgrind/valgrind.h... no
2024/02/21 20:24:12 INFO checking for endian.h... yes
2024/02/21 20:24:12 INFO checking for sys/endian.h... no
2024/02/21 20:24:12 INFO checking for sys/param.h... yes
2024/02/21 20:24:12 INFO checking whether it is safe to define __EXTENSIONS__... yes
2024/02/21 20:24:12 INFO checking whether _XOPEN_SOURCE should be defined... no
2024/02/21 20:24:12 INFO checking for x86_64-pc-linux-gnu-gcc option to enable large file support... none needed
2024/02/21 20:24:12 INFO checking whether C compiler accepts -Werror=unknown-warning-option... no
2024/02/21 20:24:12 INFO checking whether C compiler accepts -Wall... yes
2024/02/21 20:24:12 INFO checking whether C compiler accepts -Wextra... yes
2024/02/21 20:24:12 INFO checking whether C compiler accepts -Walloc-zero... yes
2024/02/21 20:24:12 INFO checking whether C compiler accepts -Walloca... yes
2024/02/21 20:24:12 INFO checking whether C compiler accepts -Wbad-function-cast... yes
2024/02/21 20:24:12 INFO checking whether C compiler accepts -Wcast-align... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wcast-qual... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wconversion... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wformat=2... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wformat-overflow=2... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wformat-signedness... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wformat-truncation=1... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wlogical-op... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wmissing-declarations... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wmissing-prototypes... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wnested-externs... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wnull-dereference... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wold-style-definition... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wpointer-arith... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wrestrict... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wshadow... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wstrict-overflow=2... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wstrict-prototypes... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wundef... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wvla... yes
2024/02/21 20:24:13 INFO checking whether C compiler accepts -Wwrite-strings... yes
2024/02/21 20:24:14 INFO checking whether C compiler accepts -Wpedantic... yes
2024/02/21 20:24:14 INFO checking whether C compiler accepts -Werror... yes
2024/02/21 20:24:14 INFO checking how to print strings... printf
2024/02/21 20:24:14 INFO checking for a sed that does not truncate output... /bin/sed
2024/02/21 20:24:16 INFO checking for grep that handles long lines and -e... /bin/grep
2024/02/21 20:24:16 INFO checking for egrep... /bin/grep -E
2024/02/21 20:24:16 INFO checking for fgrep... /bin/grep -F
2024/02/21 20:24:16 INFO checking for ld used by x86_64-pc-linux-gnu-gcc... /usr/x86_64-pc-linux-gnu/bin/ld
2024/02/21 20:24:16 INFO checking if the linker (/usr/x86_64-pc-linux-gnu/bin/ld) is GNU ld... yes
2024/02/21 20:24:16 INFO checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
2024/02/21 20:24:16 INFO checking the name lister (/usr/bin/nm -B) interface... BSD nm
2024/02/21 20:24:16 INFO checking the maximum length of command line arguments... 32768
2024/02/21 20:24:16 INFO checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
2024/02/21 20:24:16 INFO checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
2024/02/21 20:24:16 INFO checking for /usr/x86_64-pc-linux-gnu/bin/ld option to reload object files... -r
2024/02/21 20:24:16 INFO checking for x86_64-pc-linux-gnu-file... no
2024/02/21 20:24:16 INFO checking for file... no
2024/02/21 20:24:16 INFO checking for x86_64-pc-linux-gnu-objdump... no
2024/02/21 20:24:16 INFO checking for objdump... objdump
2024/02/21 20:24:16 INFO checking how to recognize dependent libraries... pass_all
2024/02/21 20:24:16 INFO checking for x86_64-pc-linux-gnu-dlltool... no
2024/02/21 20:24:16 INFO checking for dlltool... no
2024/02/21 20:24:16 INFO checking how to associate runtime and link libraries... printf %s\n
2024/02/21 20:24:16 INFO checking for x86_64-pc-linux-gnu-ar... no
2024/02/21 20:24:16 INFO checking for ar... ar
2024/02/21 20:24:16 INFO checking for archiver @FILE support... @
2024/02/21 20:24:16 INFO checking for x86_64-pc-linux-gnu-strip... no
2024/02/21 20:24:16 INFO checking for strip... strip
2024/02/21 20:24:16 INFO checking for x86_64-pc-linux-gnu-ranlib... no
2024/02/21 20:24:16 INFO checking for ranlib... ranlib
2024/02/21 20:24:17 INFO checking command to parse /usr/bin/nm -B output from x86_64-pc-linux-gnu-gcc object... ok
2024/02/21 20:24:17 INFO checking for sysroot... no
2024/02/21 20:24:17 INFO checking for a working dd... /bin/dd
2024/02/21 20:24:17 INFO checking how to truncate binary pipes... /bin/dd bs=4096 count=1
2024/02/21 20:24:17 INFO checking for x86_64-pc-linux-gnu-mt... no
2024/02/21 20:24:17 INFO checking for mt... no
2024/02/21 20:24:17 INFO checking if : is a manifest tool... no
2024/02/21 20:24:17 INFO checking for dlfcn.h... yes
2024/02/21 20:24:17 INFO checking for objdir... .libs
2024/02/21 20:24:18 INFO checking if x86_64-pc-linux-gnu-gcc supports -fno-rtti -fno-exceptions... no
2024/02/21 20:24:18 INFO checking for x86_64-pc-linux-gnu-gcc option to produce PIC... -fPIC -DPIC
2024/02/21 20:24:18 INFO checking if x86_64-pc-linux-gnu-gcc PIC flag -fPIC -DPIC works... yes
2024/02/21 20:24:18 INFO checking if x86_64-pc-linux-gnu-gcc static flag -static works... yes
2024/02/21 20:24:18 INFO checking if x86_64-pc-linux-gnu-gcc supports -c -o file.o... yes
2024/02/21 20:24:18 INFO checking if x86_64-pc-linux-gnu-gcc supports -c -o file.o... (cached) yes
2024/02/21 20:24:18 INFO checking whether the x86_64-pc-linux-gnu-gcc linker (/usr/x86_64-pc-linux-gnu/bin/ld) supports shared libraries... yes
2024/02/21 20:24:18 INFO checking whether -lc should be explicitly linked in... no
2024/02/21 20:24:19 INFO checking dynamic linker characteristics... GNU/Linux ld.so
2024/02/21 20:24:19 INFO checking how to hardcode library paths into programs... immediate
2024/02/21 20:24:19 INFO checking whether stripping libraries is possible... yes
2024/02/21 20:24:19 INFO checking if libtool supports shared libraries... yes
2024/02/21 20:24:19 INFO checking whether to build shared libraries... yes
2024/02/21 20:24:19 INFO checking whether to build static libraries... no
2024/02/21 20:24:19 INFO checking for _ prefix in compiled symbols... no
2024/02/21 20:24:19 INFO checking whether the preprocessor (x86_64-pc-linux-gnu-gcc -E) supports -dD... yes
2024/02/21 20:24:19 INFO checking whether we are compiling with ASan... no
2024/02/21 20:24:20 INFO checking whether sys/cdefs.h defines __BEGIN_DECLS and __END_DECLS... yes
2024/02/21 20:24:20 INFO checking whether sys/cdefs.h defines __THROW... yes
2024/02/21 20:24:20 INFO checking how to control data alignment... _Alignas
2024/02/21 20:24:20 INFO checking how to query data alignment... _Alignof
2024/02/21 20:24:20 INFO checking for max_align_t in stddef.h... yes
2024/02/21 20:24:20 INFO checking for byte order macros... BYTE_ORDER and xxx_ENDIAN
2024/02/21 20:24:20 INFO checking for static_assert in assert.h... yes
2024/02/21 20:24:21 INFO checking for ld --wrap... yes
2024/02/21 20:24:21 INFO checking linker version script flag... --version-script
2024/02/21 20:24:22 INFO checking if version scripts can use complex wildcards... yes
2024/02/21 20:24:22 INFO checking for __attribute__((symver))... no
2024/02/21 20:24:23 INFO checking how to make linking fail when undefined symbols remain... -Wl,-z,defs
2024/02/21 20:24:23 INFO checking how to make linking fail when there are text relocations... -Wl,-z,text
2024/02/21 20:24:23 INFO checking how to link with read-only relocations... -Wl,-z,relro
2024/02/21 20:24:24 INFO checking how to link with immediate binding... -Wl,-z,now
2024/02/21 20:24:24 INFO checking whether C compiler accepts -fno-plt... yes
2024/02/21 20:24:24 INFO checking for arc4random_buf... yes
2024/02/21 20:24:25 INFO checking for explicit_bzero... yes
2024/02/21 20:24:25 INFO checking for explicit_memset... no
2024/02/21 20:24:26 INFO checking for getentropy... yes
2024/02/21 20:24:26 INFO checking for getrandom... yes
2024/02/21 20:24:26 INFO checking for memset_s... no
2024/02/21 20:24:27 INFO checking for open64... yes
2024/02/21 20:24:27 INFO checking for syscall... yes
2024/02/21 20:24:27 INFO checking for valgrind... no
2024/02/21 20:24:27 INFO checking for Python 3.>=6 with Passlib... not found
2024/02/21 20:24:27 INFO configure: Disabling the "regen-ka-table" target, missing Python requirements.
2024/02/21 20:24:28 INFO checking whether all ucontext.h functions are available... yes
2024/02/21 20:24:28 INFO checking that generated files are newer than configure... done
2024/02/21 20:24:28 INFO configure: creating ./config.status
2024/02/21 20:24:28 INFO config.status: creating Makefile
2024/02/21 20:24:28 INFO config.status: creating libxcrypt.pc
2024/02/21 20:24:28 INFO config.status: creating config.h
2024/02/21 20:24:28 INFO config.status: executing depfiles commands
2024/02/21 20:24:28 INFO config.status: executing libtool commands
2024/02/21 20:24:28 INFO running step "autoconf/configure"
2024/02/21 20:24:28 INFO running step "Run autoconf configure script"
2024/02/21 20:24:28 INFO executing: bwrap --bind /tmp/melange-guest-4074152788 / --bind /tmp/melange-workspace-66114320 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv HOME /home/build --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv SOURCE_DATE_EPOCH 0 --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv GOFLAGS  --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap --setenv GOPATH /home/build/.cache/go --setenv GOTOOLCHAIN local --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
cd .
./configure \
  --host=x86_64-pc-linux-gnu \
  --build=x86_64-pc-linux-gnu \
  --prefix=/usr \
  --sysconfdir=/etc \
  --libdir=/usr/lib \
  --mandir=/usr/share/man \
  --infodir=/usr/share/info \
  --localstatedir=/var \
  

exit 0
2024/02/21 20:24:28 INFO checking for a BSD-compatible install... /usr/bin/install -c
2024/02/21 20:24:28 INFO checking whether build environment is sane... yes
2024/02/21 20:24:28 INFO checking for a race-free mkdir -p... /bin/mkdir -p
2024/02/21 20:24:28 INFO checking for gawk... no
2024/02/21 20:24:28 INFO checking for mawk... no
2024/02/21 20:24:28 INFO checking for nawk... no
2024/02/21 20:24:28 INFO checking for awk... awk
2024/02/21 20:24:28 INFO checking whether make sets $(MAKE)... yes
2024/02/21 20:24:28 INFO checking whether make supports nested variables... yes
2024/02/21 20:24:28 INFO checking build system type... x86_64-pc-linux-gnu
2024/02/21 20:24:28 INFO checking host system type... x86_64-pc-linux-gnu
2024/02/21 20:24:28 INFO checking for x86_64-pc-linux-gnu-gcc... x86_64-pc-linux-gnu-gcc
2024/02/21 20:24:29 INFO checking whether the C compiler works... yes
2024/02/21 20:24:29 INFO checking for C compiler default output file name... a.out
2024/02/21 20:24:29 INFO checking for suffix of executables... 
2024/02/21 20:24:29 INFO checking whether we are cross compiling... no
2024/02/21 20:24:29 INFO checking for suffix of object files... o
2024/02/21 20:24:29 INFO checking whether the compiler supports GNU C... yes
2024/02/21 20:24:29 INFO checking whether x86_64-pc-linux-gnu-gcc accepts -g... yes
2024/02/21 20:24:30 INFO checking for x86_64-pc-linux-gnu-gcc option to enable C11 features... none needed
2024/02/21 20:24:30 INFO checking whether x86_64-pc-linux-gnu-gcc understands -c and -o together... yes
2024/02/21 20:24:30 INFO checking whether make supports the include directive... yes (GNU style)
2024/02/21 20:24:30 INFO checking dependency style of x86_64-pc-linux-gnu-gcc... gcc3
2024/02/21 20:24:30 WARN ./configure: line 4760: PKG_PROG_PKG_CONFIG: not found
2024/02/21 20:24:30 WARN ./configure: line 4761: --atleast-pkgconfig-version: not found
2024/02/21 20:24:30 INFO checking how to run the C preprocessor... x86_64-pc-linux-gnu-gcc -E
2024/02/21 20:24:30 INFO checking whether make sets $(MAKE)... (cached) yes
2024/02/21 20:24:30 INFO checking whether ln -s works... yes
2024/02/21 20:24:30 INFO checking for perl... /usr/bin/perl
2024/02/21 20:24:30 INFO checking whether /usr/bin/perl is version 5.14.0 or later... yes
2024/02/21 20:24:30 INFO checking for gpg2... false
2024/02/21 20:24:30 INFO checking for sha256sum... /usr/bin/sha256sum
2024/02/21 20:24:30 INFO checking for stdio.h... yes
2024/02/21 20:24:30 INFO checking for stdlib.h... yes
2024/02/21 20:24:30 INFO checking for string.h... yes
2024/02/21 20:24:30 INFO checking for inttypes.h... yes
2024/02/21 20:24:30 INFO checking for stdint.h... yes
2024/02/21 20:24:30 INFO checking for strings.h... yes
2024/02/21 20:24:30 INFO checking for sys/stat.h... yes
2024/02/21 20:24:30 INFO checking for sys/types.h... yes
2024/02/21 20:24:30 INFO checking for unistd.h... yes
2024/02/21 20:24:30 INFO checking for wchar.h... yes
2024/02/21 20:24:30 INFO checking for minix/config.h... no
2024/02/21 20:24:30 INFO checking for fcntl.h... yes
2024/02/21 20:24:30 INFO checking for stdbool.h... yes
2024/02/21 20:24:30 INFO checking for ucontext.h... yes
2024/02/21 20:24:30 INFO checking for sys/cdefs.h... yes
2024/02/21 20:24:30 INFO checking for sys/random.h... yes
2024/02/21 20:24:30 INFO checking for sys/syscall.h... yes
2024/02/21 20:24:30 INFO checking for valgrind/valgrind.h... no
2024/02/21 20:24:30 INFO checking for endian.h... yes
2024/02/21 20:24:30 INFO checking for sys/endian.h... no
2024/02/21 20:24:30 INFO checking for sys/param.h... yes
2024/02/21 20:24:30 INFO checking whether it is safe to define __EXTENSIONS__... yes
2024/02/21 20:24:30 INFO checking whether _XOPEN_SOURCE should be defined... no
2024/02/21 20:24:30 INFO checking for x86_64-pc-linux-gnu-gcc option to enable large file support... none needed
2024/02/21 20:24:30 INFO checking whether C compiler accepts -Werror=unknown-warning-option... no
2024/02/21 20:24:30 INFO checking whether C compiler accepts -Wall... yes
2024/02/21 20:24:30 INFO checking whether C compiler accepts -Wextra... yes
2024/02/21 20:24:30 INFO checking whether C compiler accepts -Walloc-zero... yes
2024/02/21 20:24:30 INFO checking whether C compiler accepts -Walloca... yes
2024/02/21 20:24:30 INFO checking whether C compiler accepts -Wbad-function-cast... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wcast-align... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wcast-qual... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wconversion... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wformat=2... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wformat-overflow=2... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wformat-signedness... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wformat-truncation=1... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wlogical-op... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wmissing-declarations... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wmissing-prototypes... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wnested-externs... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wnull-dereference... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wold-style-definition... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wpointer-arith... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wrestrict... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wshadow... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wstrict-overflow=2... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wstrict-prototypes... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wundef... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wvla... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wwrite-strings... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Wpedantic... yes
2024/02/21 20:24:31 INFO checking whether C compiler accepts -Werror... yes
2024/02/21 20:24:31 INFO checking how to print strings... printf
2024/02/21 20:24:31 INFO checking for a sed that does not truncate output... /bin/sed
2024/02/21 20:24:31 INFO checking for grep that handles long lines and -e... /bin/grep
2024/02/21 20:24:31 INFO checking for egrep... /bin/grep -E
2024/02/21 20:24:31 INFO checking for fgrep... /bin/grep -F
2024/02/21 20:24:31 INFO checking for ld used by x86_64-pc-linux-gnu-gcc... /usr/x86_64-pc-linux-gnu/bin/ld
2024/02/21 20:24:31 INFO checking if the linker (/usr/x86_64-pc-linux-gnu/bin/ld) is GNU ld... yes
2024/02/21 20:24:31 INFO checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
2024/02/21 20:24:31 INFO checking the name lister (/usr/bin/nm -B) interface... BSD nm
2024/02/21 20:24:31 INFO checking the maximum length of command line arguments... 32768
2024/02/21 20:24:31 INFO checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
2024/02/21 20:24:31 INFO checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
2024/02/21 20:24:31 INFO checking for /usr/x86_64-pc-linux-gnu/bin/ld option to reload object files... -r
2024/02/21 20:24:31 INFO checking for x86_64-pc-linux-gnu-file... no
2024/02/21 20:24:31 INFO checking for file... no
2024/02/21 20:24:31 INFO checking for x86_64-pc-linux-gnu-objdump... no
2024/02/21 20:24:31 INFO checking for objdump... objdump
2024/02/21 20:24:31 INFO checking how to recognize dependent libraries... pass_all
2024/02/21 20:24:31 INFO checking for x86_64-pc-linux-gnu-dlltool... no
2024/02/21 20:24:31 INFO checking for dlltool... no
2024/02/21 20:24:31 INFO checking how to associate runtime and link libraries... printf %s\n
2024/02/21 20:24:31 INFO checking for x86_64-pc-linux-gnu-ar... no
2024/02/21 20:24:31 INFO checking for ar... ar
2024/02/21 20:24:31 INFO checking for archiver @FILE support... @
2024/02/21 20:24:31 INFO checking for x86_64-pc-linux-gnu-strip... no
2024/02/21 20:24:31 INFO checking for strip... strip
2024/02/21 20:24:31 INFO checking for x86_64-pc-linux-gnu-ranlib... no
2024/02/21 20:24:31 INFO checking for ranlib... ranlib
2024/02/21 20:24:31 INFO checking command to parse /usr/bin/nm -B output from x86_64-pc-linux-gnu-gcc object... ok
2024/02/21 20:24:31 INFO checking for sysroot... no
2024/02/21 20:24:31 INFO checking for a working dd... /bin/dd
2024/02/21 20:24:31 INFO checking how to truncate binary pipes... /bin/dd bs=4096 count=1
2024/02/21 20:24:31 INFO checking for x86_64-pc-linux-gnu-mt... no
2024/02/21 20:24:31 INFO checking for mt... no
2024/02/21 20:24:31 INFO checking if : is a manifest tool... no
2024/02/21 20:24:31 INFO checking for dlfcn.h... yes
2024/02/21 20:24:31 INFO checking for objdir... .libs
2024/02/21 20:24:31 INFO checking if x86_64-pc-linux-gnu-gcc supports -fno-rtti -fno-exceptions... no
2024/02/21 20:24:31 INFO checking for x86_64-pc-linux-gnu-gcc option to produce PIC... -fPIC -DPIC
2024/02/21 20:24:31 INFO checking if x86_64-pc-linux-gnu-gcc PIC flag -fPIC -DPIC works... yes
2024/02/21 20:24:31 INFO checking if x86_64-pc-linux-gnu-gcc static flag -static works... yes
2024/02/21 20:24:31 INFO checking if x86_64-pc-linux-gnu-gcc supports -c -o file.o... yes
2024/02/21 20:24:31 INFO checking if x86_64-pc-linux-gnu-gcc supports -c -o file.o... (cached) yes
2024/02/21 20:24:31 INFO checking whether the x86_64-pc-linux-gnu-gcc linker (/usr/x86_64-pc-linux-gnu/bin/ld) supports shared libraries... yes
2024/02/21 20:24:31 INFO checking whether -lc should be explicitly linked in... no
2024/02/21 20:24:31 INFO checking dynamic linker characteristics... GNU/Linux ld.so
2024/02/21 20:24:31 INFO checking how to hardcode library paths into programs... immediate
2024/02/21 20:24:31 INFO checking whether stripping libraries is possible... yes
2024/02/21 20:24:31 INFO checking if libtool supports shared libraries... yes
2024/02/21 20:24:31 INFO checking whether to build shared libraries... yes
2024/02/21 20:24:31 INFO checking whether to build static libraries... yes
2024/02/21 20:24:31 INFO checking for _ prefix in compiled symbols... no
2024/02/21 20:24:31 INFO checking whether the preprocessor (x86_64-pc-linux-gnu-gcc -E) supports -dD... yes
2024/02/21 20:24:31 INFO checking whether we are compiling with ASan... no
2024/02/21 20:24:31 INFO checking whether sys/cdefs.h defines __BEGIN_DECLS and __END_DECLS... yes
2024/02/21 20:24:32 INFO checking whether sys/cdefs.h defines __THROW... yes
2024/02/21 20:24:32 INFO checking how to control data alignment... _Alignas
2024/02/21 20:24:32 INFO checking how to query data alignment... _Alignof
2024/02/21 20:24:32 INFO checking for max_align_t in stddef.h... yes
2024/02/21 20:24:32 INFO checking for byte order macros... BYTE_ORDER and xxx_ENDIAN
2024/02/21 20:24:32 INFO checking for static_assert in assert.h... yes
2024/02/21 20:24:32 INFO checking for ld --wrap... yes
2024/02/21 20:24:32 INFO checking linker version script flag... --version-script
2024/02/21 20:24:32 INFO checking if version scripts can use complex wildcards... yes
2024/02/21 20:24:32 INFO checking for __attribute__((symver))... no
2024/02/21 20:24:32 INFO checking how to make linking fail when undefined symbols remain... -Wl,-z,defs
2024/02/21 20:24:32 INFO checking how to make linking fail when there are text relocations... -Wl,-z,text
2024/02/21 20:24:32 INFO checking how to link with read-only relocations... -Wl,-z,relro
2024/02/21 20:24:32 INFO checking how to link with immediate binding... -Wl,-z,now
2024/02/21 20:24:32 INFO checking whether C compiler accepts -fno-plt... yes
2024/02/21 20:24:32 INFO checking for arc4random_buf... yes
2024/02/21 20:24:32 INFO checking for explicit_bzero... yes
2024/02/21 20:24:32 INFO checking for explicit_memset... no
2024/02/21 20:24:32 INFO checking for getentropy... yes
2024/02/21 20:24:32 INFO checking for getrandom... yes
2024/02/21 20:24:32 INFO checking for memset_s... no
2024/02/21 20:24:32 INFO checking for open64... yes
2024/02/21 20:24:32 INFO checking for syscall... yes
2024/02/21 20:24:32 INFO checking for valgrind... no
2024/02/21 20:24:32 INFO checking for Python 3.>=6 with Passlib... not found
2024/02/21 20:24:32 INFO configure: Disabling the "regen-ka-table" target, missing Python requirements.
2024/02/21 20:24:32 INFO checking whether all ucontext.h functions are available... yes
2024/02/21 20:24:32 INFO checking minimum symbol version to use for compatibility symbols... GLIBC_2.2.5
2024/02/21 20:24:32 INFO checking that generated files are newer than configure... done
2024/02/21 20:24:32 INFO configure: creating ./config.status
2024/02/21 20:24:33 INFO config.status: creating Makefile
2024/02/21 20:24:33 INFO config.status: creating libxcrypt.pc
2024/02/21 20:24:33 INFO config.status: creating config.h
2024/02/21 20:24:33 INFO config.status: executing depfiles commands
2024/02/21 20:24:33 INFO config.status: executing libtool commands
2024/02/21 20:24:33 INFO running step "autoconf/make"
2024/02/21 20:24:33 INFO running step "Run autoconf make"
2024/02/21 20:24:33 INFO executing: bwrap --bind /tmp/melange-guest-4074152788 / --bind /tmp/melange-workspace-66114320 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv SOURCE_DATE_EPOCH 0 --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv GOFLAGS  --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap --setenv HOME /home/build --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv GOPATH /home/build/.cache/go --setenv GOTOOLCHAIN local --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
make -C "." -j$(nproc) V=1 

exit 0
2024/02/21 20:24:33 INFO make: Entering directory '/home/build'
2024/02/21 20:24:33 INFO make  all-am
2024/02/21 20:24:33 INFO make[1]: Entering directory '/home/build'
2024/02/21 20:24:33 INFO LC_ALL=C /usr/bin/perl ./build-aux/scripts/gen-libcrypt-map \
2024/02/21 20:24:33 INFO   SYMVER_MIN=GLIBC_2.0 \
2024/02/21 20:24:33 INFO   SYMVER_FLOOR=GLIBC_2.2.5 \
2024/02/21 20:24:33 INFO   COMPAT_ABI=yes \
2024/02/21 20:24:33 INFO   ./lib/libcrypt.map.in > libcrypt.map.T
2024/02/21 20:24:33 INFO LC_ALL=C /usr/bin/perl \
2024/02/21 20:24:33 INFO   ./build-aux/scripts/gen-crypt-h \
2024/02/21 20:24:33 INFO   ./lib/xcrypt.h.in config.h \
2024/02/21 20:24:33 INFO   > xcrypt.h.T
2024/02/21 20:24:33 INFO depbase=`echo lib/gen-des-tables.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
2024/02/21 20:24:33 INFO x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/gen-des-tables.o -MD -MP -MF $depbase.Tpo -c -o lib/gen-des-tables.o lib/gen-des-tables.c &&\
2024/02/21 20:24:33 INFO mv -f $depbase.Tpo $depbase.Po
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-des-tables.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-des-tables.Tpo -c -o lib/libcrypt_la-alg-des-tables.lo `test -f 'lib/alg-des-tables.c' || echo './'`lib/alg-des-tables.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-des.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-des.Tpo -c -o lib/libcrypt_la-alg-des.lo `test -f 'lib/alg-des.c' || echo './'`lib/alg-des.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-gost3411-2012-core.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-gost3411-2012-core.Tpo -c -o lib/libcrypt_la-alg-gost3411-2012-core.lo `test -f 'lib/alg-gost3411-2012-core.c' || echo './'`lib/alg-gost3411-2012-core.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-gost3411-2012-hmac.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-gost3411-2012-hmac.Tpo -c -o lib/libcrypt_la-alg-gost3411-2012-hmac.lo `test -f 'lib/alg-gost3411-2012-hmac.c' || echo './'`lib/alg-gost3411-2012-hmac.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-hmac-sha1.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-hmac-sha1.Tpo -c -o lib/libcrypt_la-alg-hmac-sha1.lo `test -f 'lib/alg-hmac-sha1.c' || echo './'`lib/alg-hmac-sha1.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-md4.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-md4.Tpo -c -o lib/libcrypt_la-alg-md4.lo `test -f 'lib/alg-md4.c' || echo './'`lib/alg-md4.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-md5.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-md5.Tpo -c -o lib/libcrypt_la-alg-md5.lo `test -f 'lib/alg-md5.c' || echo './'`lib/alg-md5.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-sha1.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-sha1.Tpo -c -o lib/libcrypt_la-alg-sha1.lo `test -f 'lib/alg-sha1.c' || echo './'`lib/alg-sha1.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-sha256.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-sha256.Tpo -c -o lib/libcrypt_la-alg-sha256.lo `test -f 'lib/alg-sha256.c' || echo './'`lib/alg-sha256.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-sha512.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-sha512.Tpo -c -o lib/libcrypt_la-alg-sha512.lo `test -f 'lib/alg-sha512.c' || echo './'`lib/alg-sha512.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-yescrypt-common.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-yescrypt-common.Tpo -c -o lib/libcrypt_la-alg-yescrypt-common.lo `test -f 'lib/alg-yescrypt-common.c' || echo './'`lib/alg-yescrypt-common.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-yescrypt-opt.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-yescrypt-opt.Tpo -c -o lib/libcrypt_la-alg-yescrypt-opt.lo `test -f 'lib/alg-yescrypt-opt.c' || echo './'`lib/alg-yescrypt-opt.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-bcrypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-bcrypt.Tpo -c -o lib/libcrypt_la-crypt-bcrypt.lo `test -f 'lib/crypt-bcrypt.c' || echo './'`lib/crypt-bcrypt.c
2024/02/21 20:24:33 INFO ./build-aux/scripts/move-if-change libcrypt.map.T libcrypt.map
2024/02/21 20:24:33 INFO ./build-aux/scripts/move-if-change xcrypt.h.T xcrypt.h
2024/02/21 20:24:33 INFO echo timestamp > xcrypt.h.stamp
2024/02/21 20:24:33 INFO echo timestamp > libcrypt.map.stamp
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-des.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-des.Tpo -c -o lib/libcrypt_la-crypt-des.lo `test -f 'lib/crypt-des.c' || echo './'`lib/crypt-des.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-gensalt-static.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-gensalt-static.Tpo -c -o lib/libcrypt_la-crypt-gensalt-static.lo `test -f 'lib/crypt-gensalt-static.c' || echo './'`lib/crypt-gensalt-static.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-md5.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-md5.Tpo -c lib/alg-md5.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-alg-md5.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-hmac-sha1.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-hmac-sha1.Tpo -c lib/alg-hmac-sha1.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-alg-hmac-sha1.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-yescrypt-opt.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-yescrypt-opt.Tpo -c lib/alg-yescrypt-opt.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-alg-yescrypt-opt.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-des-tables.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-des-tables.Tpo -c lib/alg-des-tables.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-alg-des-tables.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-gost3411-2012-hmac.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-gost3411-2012-hmac.Tpo -c lib/alg-gost3411-2012-hmac.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-alg-gost3411-2012-hmac.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-sha512.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-sha512.Tpo -c lib/alg-sha512.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-alg-sha512.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-yescrypt-common.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-yescrypt-common.Tpo -c lib/alg-yescrypt-common.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-alg-yescrypt-common.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-md4.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-md4.Tpo -c lib/alg-md4.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-alg-md4.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-sha256.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-sha256.Tpo -c lib/alg-sha256.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-alg-sha256.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-gost3411-2012-core.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-gost3411-2012-core.Tpo -c lib/alg-gost3411-2012-core.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-alg-gost3411-2012-core.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-des.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-des.Tpo -c lib/alg-des.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-alg-des.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-bcrypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-bcrypt.Tpo -c lib/crypt-bcrypt.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-bcrypt.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-sha1.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-sha1.Tpo -c lib/alg-sha1.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-alg-sha1.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-gensalt-static.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-gensalt-static.Tpo -c lib/crypt-gensalt-static.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-gensalt-static.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-des.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-des.Tpo -c lib/crypt-des.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-des.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-hmac-sha1.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-hmac-sha1.Tpo -c lib/alg-hmac-sha1.c -o lib/libcrypt_la-alg-hmac-sha1.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-gost3411-2012-hmac.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-gost3411-2012-hmac.Tpo -c lib/alg-gost3411-2012-hmac.c -o lib/libcrypt_la-alg-gost3411-2012-hmac.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-gensalt-static.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-gensalt-static.Tpo -c lib/crypt-gensalt-static.c -o lib/libcrypt_la-crypt-gensalt-static.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-des-tables.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-des-tables.Tpo -c lib/alg-des-tables.c -o lib/libcrypt_la-alg-des-tables.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-crypt-gensalt-static.Tpo lib/.deps/libcrypt_la-crypt-gensalt-static.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-gost-yescrypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-gost-yescrypt.Tpo -c -o lib/libcrypt_la-crypt-gost-yescrypt.lo `test -f 'lib/crypt-gost-yescrypt.c' || echo './'`lib/crypt-gost-yescrypt.c
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-md5.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-md5.Tpo -c -o lib/libcrypt_la-crypt-md5.lo `test -f 'lib/crypt-md5.c' || echo './'`lib/crypt-md5.c
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-alg-hmac-sha1.Tpo lib/.deps/libcrypt_la-alg-hmac-sha1.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-nthash.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-nthash.Tpo -c -o lib/libcrypt_la-crypt-nthash.lo `test -f 'lib/crypt-nthash.c' || echo './'`lib/crypt-nthash.c
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-alg-gost3411-2012-hmac.Tpo lib/.deps/libcrypt_la-alg-gost3411-2012-hmac.Plo
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-des.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-des.Tpo -c lib/alg-des.c -o lib/libcrypt_la-alg-des.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-pbkdf1-sha1.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-pbkdf1-sha1.Tpo -c -o lib/libcrypt_la-crypt-pbkdf1-sha1.lo `test -f 'lib/crypt-pbkdf1-sha1.c' || echo './'`lib/crypt-pbkdf1-sha1.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-gost-yescrypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-gost-yescrypt.Tpo -c lib/crypt-gost-yescrypt.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-gost-yescrypt.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-md5.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-md5.Tpo -c lib/crypt-md5.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-md5.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-pbkdf1-sha1.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-pbkdf1-sha1.Tpo -c lib/crypt-pbkdf1-sha1.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-pbkdf1-sha1.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-md4.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-md4.Tpo -c lib/alg-md4.c -o lib/libcrypt_la-alg-md4.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-nthash.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-nthash.Tpo -c lib/crypt-nthash.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-nthash.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-md5.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-md5.Tpo -c lib/alg-md5.c -o lib/libcrypt_la-alg-md5.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-alg-des-tables.Tpo lib/.deps/libcrypt_la-alg-des-tables.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-scrypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-scrypt.Tpo -c -o lib/libcrypt_la-crypt-scrypt.lo `test -f 'lib/crypt-scrypt.c' || echo './'`lib/crypt-scrypt.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-gost3411-2012-core.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-gost3411-2012-core.Tpo -c lib/alg-gost3411-2012-core.c -o lib/libcrypt_la-alg-gost3411-2012-core.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-des.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-des.Tpo -c lib/crypt-des.c -o lib/libcrypt_la-crypt-des.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-scrypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-scrypt.Tpo -c lib/crypt-scrypt.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-scrypt.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-sha512.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-sha512.Tpo -c lib/alg-sha512.c -o lib/libcrypt_la-alg-sha512.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-nthash.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-nthash.Tpo -c lib/crypt-nthash.c -o lib/libcrypt_la-crypt-nthash.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-gost-yescrypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-gost-yescrypt.Tpo -c lib/crypt-gost-yescrypt.c -o lib/libcrypt_la-crypt-gost-yescrypt.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-pbkdf1-sha1.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-pbkdf1-sha1.Tpo -c lib/crypt-pbkdf1-sha1.c -o lib/libcrypt_la-crypt-pbkdf1-sha1.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-yescrypt-common.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-yescrypt-common.Tpo -c lib/alg-yescrypt-common.c -o lib/libcrypt_la-alg-yescrypt-common.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-md5.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-md5.Tpo -c lib/crypt-md5.c -o lib/libcrypt_la-crypt-md5.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-alg-des.Tpo lib/.deps/libcrypt_la-alg-des.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-sha256.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-sha256.Tpo -c -o lib/libcrypt_la-crypt-sha256.lo `test -f 'lib/crypt-sha256.c' || echo './'`lib/crypt-sha256.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-sha1.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-sha1.Tpo -c lib/alg-sha1.c -o lib/libcrypt_la-alg-sha1.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-sha256.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-sha256.Tpo -c lib/crypt-sha256.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-sha256.o
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-crypt-nthash.Tpo lib/.deps/libcrypt_la-crypt-nthash.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-sha512.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-sha512.Tpo -c -o lib/libcrypt_la-crypt-sha512.lo `test -f 'lib/crypt-sha512.c' || echo './'`lib/crypt-sha512.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-scrypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-scrypt.Tpo -c lib/crypt-scrypt.c -o lib/libcrypt_la-crypt-scrypt.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-crypt-gost-yescrypt.Tpo lib/.deps/libcrypt_la-crypt-gost-yescrypt.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-static.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-static.Tpo -c -o lib/libcrypt_la-crypt-static.lo `test -f 'lib/crypt-static.c' || echo './'`lib/crypt-static.c
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-alg-md4.Tpo lib/.deps/libcrypt_la-alg-md4.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-sunmd5.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-sunmd5.Tpo -c -o lib/libcrypt_la-crypt-sunmd5.lo `test -f 'lib/crypt-sunmd5.c' || echo './'`lib/crypt-sunmd5.c
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-alg-md5.Tpo lib/.deps/libcrypt_la-alg-md5.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-yescrypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-yescrypt.Tpo -c -o lib/libcrypt_la-crypt-yescrypt.lo `test -f 'lib/crypt-yescrypt.c' || echo './'`lib/crypt-yescrypt.c
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-crypt-des.Tpo lib/.deps/libcrypt_la-crypt-des.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt.Tpo -c -o lib/libcrypt_la-crypt.lo `test -f 'lib/crypt.c' || echo './'`lib/crypt.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-static.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-static.Tpo -c lib/crypt-static.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-static.o
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-crypt-md5.Tpo lib/.deps/libcrypt_la-crypt-md5.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-base64.lo -MD -MP -MF lib/.deps/libcrypt_la-util-base64.Tpo -c -o lib/libcrypt_la-util-base64.lo `test -f 'lib/util-base64.c' || echo './'`lib/util-base64.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-sha512.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-sha512.Tpo -c lib/crypt-sha512.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-sha512.o
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-crypt-pbkdf1-sha1.Tpo lib/.deps/libcrypt_la-crypt-pbkdf1-sha1.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-gensalt-sha.lo -MD -MP -MF lib/.deps/libcrypt_la-util-gensalt-sha.Tpo -c -o lib/libcrypt_la-util-gensalt-sha.lo `test -f 'lib/util-gensalt-sha.c' || echo './'`lib/util-gensalt-sha.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-yescrypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-yescrypt.Tpo -c lib/crypt-yescrypt.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-yescrypt.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt.Tpo -c lib/crypt.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-sunmd5.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-sunmd5.Tpo -c lib/crypt-sunmd5.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-sunmd5.o
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-sha256.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-sha256.Tpo -c lib/alg-sha256.c -o lib/libcrypt_la-alg-sha256.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-alg-gost3411-2012-core.Tpo lib/.deps/libcrypt_la-alg-gost3411-2012-core.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-get-random-bytes.lo -MD -MP -MF lib/.deps/libcrypt_la-util-get-random-bytes.Tpo -c -o lib/libcrypt_la-util-get-random-bytes.lo `test -f 'lib/util-get-random-bytes.c' || echo './'`lib/util-get-random-bytes.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-static.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-static.Tpo -c lib/crypt-static.c -o lib/libcrypt_la-crypt-static.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-gensalt-sha.lo -MD -MP -MF lib/.deps/libcrypt_la-util-gensalt-sha.Tpo -c lib/util-gensalt-sha.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-util-gensalt-sha.o
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-crypt-scrypt.Tpo lib/.deps/libcrypt_la-crypt-scrypt.Plo
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-base64.lo -MD -MP -MF lib/.deps/libcrypt_la-util-base64.Tpo -c lib/util-base64.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-util-base64.o
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-make-failure-token.lo -MD -MP -MF lib/.deps/libcrypt_la-util-make-failure-token.Tpo -c -o lib/libcrypt_la-util-make-failure-token.lo `test -f 'lib/util-make-failure-token.c' || echo './'`lib/util-make-failure-token.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-base64.lo -MD -MP -MF lib/.deps/libcrypt_la-util-base64.Tpo -c lib/util-base64.c -o lib/libcrypt_la-util-base64.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-crypt-static.Tpo lib/.deps/libcrypt_la-crypt-static.Plo
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-get-random-bytes.lo -MD -MP -MF lib/.deps/libcrypt_la-util-get-random-bytes.Tpo -c lib/util-get-random-bytes.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-util-get-random-bytes.o
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-xbzero.lo -MD -MP -MF lib/.deps/libcrypt_la-util-xbzero.Tpo -c -o lib/libcrypt_la-util-xbzero.lo `test -f 'lib/util-xbzero.c' || echo './'`lib/util-xbzero.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-yescrypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-yescrypt.Tpo -c lib/crypt-yescrypt.c -o lib/libcrypt_la-crypt-yescrypt.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-sha256.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-sha256.Tpo -c lib/crypt-sha256.c -o lib/libcrypt_la-crypt-sha256.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-alg-sha512.Tpo lib/.deps/libcrypt_la-alg-sha512.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-xstrcpy.lo -MD -MP -MF lib/.deps/libcrypt_la-util-xstrcpy.Tpo -c -o lib/libcrypt_la-util-xstrcpy.lo `test -f 'lib/util-xstrcpy.c' || echo './'`lib/util-xstrcpy.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-make-failure-token.lo -MD -MP -MF lib/.deps/libcrypt_la-util-make-failure-token.Tpo -c lib/util-make-failure-token.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-util-make-failure-token.o
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-util-base64.Tpo lib/.deps/libcrypt_la-util-base64.Plo
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=compile x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.  -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-des-obsolete.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-des-obsolete.Tpo -c -o lib/libcrypt_la-crypt-des-obsolete.lo `test -f 'lib/crypt-des-obsolete.c' || echo './'`lib/crypt-des-obsolete.c
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-gensalt-sha.lo -MD -MP -MF lib/.deps/libcrypt_la-util-gensalt-sha.Tpo -c lib/util-gensalt-sha.c -o lib/libcrypt_la-util-gensalt-sha.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-xbzero.lo -MD -MP -MF lib/.deps/libcrypt_la-util-xbzero.Tpo -c lib/util-xbzero.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-util-xbzero.o
2024/02/21 20:24:33 INFO mv -f lib/.deps/libcrypt_la-alg-yescrypt-common.Tpo lib/.deps/libcrypt_la-alg-yescrypt-common.Plo
2024/02/21 20:24:33 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt.Tpo -c lib/crypt.c -o lib/libcrypt_la-crypt.o >/dev/null 2>&1
2024/02/21 20:24:33 INFO /bin/sh ./libtool  --tag=CC   --mode=link x86_64-pc-linux-gnu-gcc -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -Wl,-z,relro -Wl,-z,now -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap -o lib/gen-des-tables lib/gen-des-tables.o  
2024/02/21 20:24:34 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-xstrcpy.lo -MD -MP -MF lib/.deps/libcrypt_la-util-xstrcpy.Tpo -c lib/util-xstrcpy.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-util-xstrcpy.o
2024/02/21 20:24:34 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-get-random-bytes.lo -MD -MP -MF lib/.deps/libcrypt_la-util-get-random-bytes.Tpo -c lib/util-get-random-bytes.c -o lib/libcrypt_la-util-get-random-bytes.o >/dev/null 2>&1
2024/02/21 20:24:34 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-make-failure-token.lo -MD -MP -MF lib/.deps/libcrypt_la-util-make-failure-token.Tpo -c lib/util-make-failure-token.c -o lib/libcrypt_la-util-make-failure-token.o >/dev/null 2>&1
2024/02/21 20:24:34 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-des-obsolete.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-des-obsolete.Tpo -c lib/crypt-des-obsolete.c  -fPIC -DPIC -o lib/.libs/libcrypt_la-crypt-des-obsolete.o
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-crypt-yescrypt.Tpo lib/.deps/libcrypt_la-crypt-yescrypt.Plo
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-alg-sha1.Tpo lib/.deps/libcrypt_la-alg-sha1.Plo
2024/02/21 20:24:34 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-xbzero.lo -MD -MP -MF lib/.deps/libcrypt_la-util-xbzero.Tpo -c lib/util-xbzero.c -o lib/libcrypt_la-util-xbzero.o >/dev/null 2>&1
2024/02/21 20:24:34 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-sunmd5.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-sunmd5.Tpo -c lib/crypt-sunmd5.c -o lib/libcrypt_la-crypt-sunmd5.o >/dev/null 2>&1
2024/02/21 20:24:34 INFO libtool: link: x86_64-pc-linux-gnu-gcc -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,--as-needed -Wl,-O1 -Wl,--sort-common -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-z -Wl,noexecstack -Wl,-z -Wl,noexecheap -o lib/gen-des-tables lib/gen-des-tables.o 
2024/02/21 20:24:34 WARN /usr/lib/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: warning: -z noexecheap ignored
2024/02/21 20:24:34 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-sha512.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-sha512.Tpo -c lib/crypt-sha512.c -o lib/libcrypt_la-crypt-sha512.o >/dev/null 2>&1
2024/02/21 20:24:34 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-util-xstrcpy.lo -MD -MP -MF lib/.deps/libcrypt_la-util-xstrcpy.Tpo -c lib/util-xstrcpy.c -o lib/libcrypt_la-util-xstrcpy.o >/dev/null 2>&1
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-util-gensalt-sha.Tpo lib/.deps/libcrypt_la-util-gensalt-sha.Plo
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-util-make-failure-token.Tpo lib/.deps/libcrypt_la-util-make-failure-token.Plo
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-util-xbzero.Tpo lib/.deps/libcrypt_la-util-xbzero.Plo
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-util-get-random-bytes.Tpo lib/.deps/libcrypt_la-util-get-random-bytes.Plo
2024/02/21 20:24:34 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-des-obsolete.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-des-obsolete.Tpo -c lib/crypt-des-obsolete.c -o lib/libcrypt_la-crypt-des-obsolete.o >/dev/null 2>&1
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-crypt-sha256.Tpo lib/.deps/libcrypt_la-crypt-sha256.Plo
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-util-xstrcpy.Tpo lib/.deps/libcrypt_la-util-xstrcpy.Plo
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-crypt.Tpo lib/.deps/libcrypt_la-crypt.Plo
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-crypt-des-obsolete.Tpo lib/.deps/libcrypt_la-crypt-des-obsolete.Plo
2024/02/21 20:24:34 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-crypt-bcrypt.lo -MD -MP -MF lib/.deps/libcrypt_la-crypt-bcrypt.Tpo -c lib/crypt-bcrypt.c -o lib/libcrypt_la-crypt-bcrypt.o >/dev/null 2>&1
2024/02/21 20:24:34 INFO libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./lib -DIN_LIBCRYPT -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -MT lib/libcrypt_la-alg-yescrypt-opt.lo -MD -MP -MF lib/.deps/libcrypt_la-alg-yescrypt-opt.Tpo -c lib/alg-yescrypt-opt.c -o lib/libcrypt_la-alg-yescrypt-opt.o >/dev/null 2>&1
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-crypt-sunmd5.Tpo lib/.deps/libcrypt_la-crypt-sunmd5.Plo
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-crypt-sha512.Tpo lib/.deps/libcrypt_la-crypt-sha512.Plo
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-alg-sha256.Tpo lib/.deps/libcrypt_la-alg-sha256.Plo
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-crypt-bcrypt.Tpo lib/.deps/libcrypt_la-crypt-bcrypt.Plo
2024/02/21 20:24:34 INFO mv -f lib/.deps/libcrypt_la-alg-yescrypt-opt.Tpo lib/.deps/libcrypt_la-alg-yescrypt-opt.Plo
2024/02/21 20:24:34 INFO /bin/sh ./libtool  --tag=CC   --mode=link x86_64-pc-linux-gnu-gcc -Wall -Wextra -Walloc-zero -Walloca -Wbad-function-cast -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Wformat-overflow=2 -Wformat-signedness -Wformat-truncation=1 -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wnull-dereference -Wold-style-definition -Wpointer-arith -Wrestrict -Wshadow -Wstrict-overflow=2 -Wstrict-prototypes -Wundef -Wvla -Wwrite-strings -Wpedantic -Werror -fno-plt -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -version-info 2:0:1 -Wl,--version-script,./libcrypt.map -Wl,-z,defs -Wl,-z,text -Wl,-z,relro -Wl,-z,now -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap -o libcrypt.la -rpath /usr/lib lib/libcrypt_la-alg-des-tables.lo lib/libcrypt_la-alg-des.lo lib/libcrypt_la-alg-gost3411-2012-core.lo lib/libcrypt_la-alg-gost3411-2012-hmac.lo lib/libcrypt_la-alg-hmac-sha1.lo lib/libcrypt_la-alg-md4.lo lib/libcrypt_la-alg-md5.lo lib/libcrypt_la-alg-sha1.lo lib/libcrypt_la-alg-sha256.lo lib/libcrypt_la-alg-sha512.lo lib/libcrypt_la-alg-yescrypt-common.lo lib/libcrypt_la-alg-yescrypt-opt.lo lib/libcrypt_la-crypt-bcrypt.lo lib/libcrypt_la-crypt-des.lo lib/libcrypt_la-crypt-gensalt-static.lo lib/libcrypt_la-crypt-gost-yescrypt.lo lib/libcrypt_la-crypt-md5.lo lib/libcrypt_la-crypt-nthash.lo lib/libcrypt_la-crypt-pbkdf1-sha1.lo lib/libcrypt_la-crypt-scrypt.lo lib/libcrypt_la-crypt-sha256.lo lib/libcrypt_la-crypt-sha512.lo lib/libcrypt_la-crypt-static.lo lib/libcrypt_la-crypt-sunmd5.lo lib/libcrypt_la-crypt-yescrypt.lo lib/libcrypt_la-crypt.lo lib/libcrypt_la-util-base64.lo lib/libcrypt_la-util-gensalt-sha.lo lib/libcrypt_la-util-get-random-bytes.lo lib/libcrypt_la-util-make-failure-token.lo lib/libcrypt_la-util-xbzero.lo lib/libcrypt_la-util-xstrcpy.lo lib/libcrypt_la-crypt-des-obsolete.lo  
2024/02/21 20:24:34 INFO libtool: link: x86_64-pc-linux-gnu-gcc -shared  -fPIC -DPIC  lib/.libs/libcrypt_la-alg-des-tables.o lib/.libs/libcrypt_la-alg-des.o lib/.libs/libcrypt_la-alg-gost3411-2012-core.o lib/.libs/libcrypt_la-alg-gost3411-2012-hmac.o lib/.libs/libcrypt_la-alg-hmac-sha1.o lib/.libs/libcrypt_la-alg-md4.o lib/.libs/libcrypt_la-alg-md5.o lib/.libs/libcrypt_la-alg-sha1.o lib/.libs/libcrypt_la-alg-sha256.o lib/.libs/libcrypt_la-alg-sha512.o lib/.libs/libcrypt_la-alg-yescrypt-common.o lib/.libs/libcrypt_la-alg-yescrypt-opt.o lib/.libs/libcrypt_la-crypt-bcrypt.o lib/.libs/libcrypt_la-crypt-des.o lib/.libs/libcrypt_la-crypt-gensalt-static.o lib/.libs/libcrypt_la-crypt-gost-yescrypt.o lib/.libs/libcrypt_la-crypt-md5.o lib/.libs/libcrypt_la-crypt-nthash.o lib/.libs/libcrypt_la-crypt-pbkdf1-sha1.o lib/.libs/libcrypt_la-crypt-scrypt.o lib/.libs/libcrypt_la-crypt-sha256.o lib/.libs/libcrypt_la-crypt-sha512.o lib/.libs/libcrypt_la-crypt-static.o lib/.libs/libcrypt_la-crypt-sunmd5.o lib/.libs/libcrypt_la-crypt-yescrypt.o lib/.libs/libcrypt_la-crypt.o lib/.libs/libcrypt_la-util-base64.o lib/.libs/libcrypt_la-util-gensalt-sha.o lib/.libs/libcrypt_la-util-get-random-bytes.o lib/.libs/libcrypt_la-util-make-failure-token.o lib/.libs/libcrypt_la-util-xbzero.o lib/.libs/libcrypt_la-util-xstrcpy.o lib/.libs/libcrypt_la-crypt-des-obsolete.o    -O2 -march=x86-64-v2 -mtune=broadwell -Wl,--version-script -Wl,./libcrypt.map -Wl,-z -Wl,defs -Wl,-z -Wl,text -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,--as-needed -Wl,-O1 -Wl,--sort-common -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-z -Wl,noexecstack -Wl,-z -Wl,noexecheap   -Wl,-soname -Wl,libcrypt.so.1 -o .libs/libcrypt.so.1.1.0
2024/02/21 20:24:34 WARN /usr/lib/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: warning: -z noexecheap ignored
2024/02/21 20:24:34 INFO libtool: link: (cd ".libs" && rm -f "libcrypt.so.1" && ln -s "libcrypt.so.1.1.0" "libcrypt.so.1")
2024/02/21 20:24:34 INFO libtool: link: (cd ".libs" && rm -f "libcrypt.so" && ln -s "libcrypt.so.1.1.0" "libcrypt.so")
2024/02/21 20:24:34 INFO libtool: link: ar cr .libs/libcrypt.a  lib/libcrypt_la-alg-des-tables.o lib/libcrypt_la-alg-des.o lib/libcrypt_la-alg-gost3411-2012-core.o lib/libcrypt_la-alg-gost3411-2012-hmac.o lib/libcrypt_la-alg-hmac-sha1.o lib/libcrypt_la-alg-md4.o lib/libcrypt_la-alg-md5.o lib/libcrypt_la-alg-sha1.o lib/libcrypt_la-alg-sha256.o lib/libcrypt_la-alg-sha512.o lib/libcrypt_la-alg-yescrypt-common.o lib/libcrypt_la-alg-yescrypt-opt.o lib/libcrypt_la-crypt-bcrypt.o lib/libcrypt_la-crypt-des.o lib/libcrypt_la-crypt-gensalt-static.o lib/libcrypt_la-crypt-gost-yescrypt.o lib/libcrypt_la-crypt-md5.o lib/libcrypt_la-crypt-nthash.o lib/libcrypt_la-crypt-pbkdf1-sha1.o lib/libcrypt_la-crypt-scrypt.o lib/libcrypt_la-crypt-sha256.o lib/libcrypt_la-crypt-sha512.o lib/libcrypt_la-crypt-static.o lib/libcrypt_la-crypt-sunmd5.o lib/libcrypt_la-crypt-yescrypt.o lib/libcrypt_la-crypt.o lib/libcrypt_la-util-base64.o lib/libcrypt_la-util-gensalt-sha.o lib/libcrypt_la-util-get-random-bytes.o lib/libcrypt_la-util-make-failure-token.o lib/libcrypt_la-util-xbzero.o lib/libcrypt_la-util-xstrcpy.o lib/libcrypt_la-crypt-des-obsolete.o
2024/02/21 20:24:34 INFO libtool: link: ranlib .libs/libcrypt.a
2024/02/21 20:24:34 INFO libtool: link: ( cd ".libs" && rm -f "libcrypt.la" && ln -s "../libcrypt.la" "libcrypt.la" )
2024/02/21 20:24:34 INFO make[1]: Leaving directory '/home/build'
2024/02/21 20:24:34 INFO make: Leaving directory '/home/build'
2024/02/21 20:24:34 INFO running step "autoconf/make-install"
2024/02/21 20:24:34 INFO running step "Run autoconf make install"
2024/02/21 20:24:34 INFO executing: bwrap --bind /tmp/melange-guest-4074152788 / --bind /tmp/melange-workspace-66114320 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv GOPATH /home/build/.cache/go --setenv GOTOOLCHAIN local --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap --setenv HOME /home/build --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv SOURCE_DATE_EPOCH 0 --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv GOFLAGS  /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
make -C "." install DESTDIR="/home/build/melange-out/libxcrypt" V=1

exit 0
2024/02/21 20:24:34 INFO make: Entering directory '/home/build'
2024/02/21 20:24:34 INFO make[1]: Entering directory '/home/build'
2024/02/21 20:24:34 INFO  /bin/mkdir -p '/home/build/melange-out/libxcrypt/usr/lib'
2024/02/21 20:24:34 INFO  /bin/sh ./libtool   --mode=install /usr/bin/install -c   libcrypt.la '/home/build/melange-out/libxcrypt/usr/lib'
2024/02/21 20:24:34 INFO libtool: install: /usr/bin/install -c .libs/libcrypt.so.1.1.0 /home/build/melange-out/libxcrypt/usr/lib/libcrypt.so.1.1.0
2024/02/21 20:24:34 INFO libtool: install: (cd /home/build/melange-out/libxcrypt/usr/lib && { ln -s -f libcrypt.so.1.1.0 libcrypt.so.1 || { rm -f libcrypt.so.1 && ln -s libcrypt.so.1.1.0 libcrypt.so.1; }; })
2024/02/21 20:24:34 INFO libtool: install: (cd /home/build/melange-out/libxcrypt/usr/lib && { ln -s -f libcrypt.so.1.1.0 libcrypt.so || { rm -f libcrypt.so && ln -s libcrypt.so.1.1.0 libcrypt.so; }; })
2024/02/21 20:24:34 INFO libtool: install: /usr/bin/install -c .libs/libcrypt.lai /home/build/melange-out/libxcrypt/usr/lib/libcrypt.la
2024/02/21 20:24:34 INFO libtool: install: /usr/bin/install -c .libs/libcrypt.a /home/build/melange-out/libxcrypt/usr/lib/libcrypt.a
2024/02/21 20:24:34 INFO libtool: install: chmod 644 /home/build/melange-out/libxcrypt/usr/lib/libcrypt.a
2024/02/21 20:24:34 INFO libtool: install: ranlib /home/build/melange-out/libxcrypt/usr/lib/libcrypt.a
2024/02/21 20:24:34 WARN libtool: warning: remember to run 'libtool --finish /usr/lib'
2024/02/21 20:24:34 INFO make  install-exec-hook
2024/02/21 20:24:34 INFO make[2]: Entering directory '/home/build'
2024/02/21 20:24:34 INFO cd /home/build/melange-out/libxcrypt/usr/lib && \
2024/02/21 20:24:34 INFO     ln -s -f libcrypt.a libxcrypt.a
2024/02/21 20:24:34 INFO cd /home/build/melange-out/libxcrypt/usr/lib && \
2024/02/21 20:24:34 INFO     ln -s -f libcrypt.so libxcrypt.so
2024/02/21 20:24:34 INFO cd /home/build/melange-out/libxcrypt/usr/lib && \
2024/02/21 20:24:34 INFO     ln -s -f libcrypt.a libowcrypt.a
2024/02/21 20:24:34 INFO cd /home/build/melange-out/libxcrypt/usr/lib && \
2024/02/21 20:24:34 INFO     ln -s -f libcrypt.so libowcrypt.so && \
2024/02/21 20:24:34 INFO     ln -s -f libcrypt.so.1 libowcrypt.so.1
2024/02/21 20:24:34 INFO make[2]: Leaving directory '/home/build'
2024/02/21 20:24:34 INFO  /bin/mkdir -p '/home/build/melange-out/libxcrypt/usr/share/man/man3'
2024/02/21 20:24:34 INFO  /usr/bin/install -c -m 644 doc/crypt.3 doc/crypt_checksalt.3 doc/crypt_gensalt.3 doc/crypt_gensalt_ra.3 doc/crypt_gensalt_rn.3 doc/crypt_preferred_method.3 doc/crypt_r.3 doc/crypt_ra.3 doc/crypt_rn.3 '/home/build/melange-out/libxcrypt/usr/share/man/man3'
2024/02/21 20:24:34 INFO  /bin/mkdir -p '/home/build/melange-out/libxcrypt/usr/share/man/man5'
2024/02/21 20:24:34 INFO  /usr/bin/install -c -m 644 doc/crypt.5 '/home/build/melange-out/libxcrypt/usr/share/man/man5'
2024/02/21 20:24:34 INFO  /bin/mkdir -p '/home/build/melange-out/libxcrypt/usr/include'
2024/02/21 20:24:34 INFO  /usr/bin/install -c -m 644 crypt.h xcrypt.h '/home/build/melange-out/libxcrypt/usr/include'
2024/02/21 20:24:34 INFO  /bin/mkdir -p '/home/build/melange-out/libxcrypt/usr/lib/pkgconfig'
2024/02/21 20:24:34 INFO  /usr/bin/install -c -m 644 libxcrypt.pc '/home/build/melange-out/libxcrypt/usr/lib/pkgconfig'
2024/02/21 20:24:34 INFO make  install-data-hook
2024/02/21 20:24:34 INFO make[2]: Entering directory '/home/build'
2024/02/21 20:24:34 INFO cd /home/build/melange-out/libxcrypt/usr/lib/pkgconfig && \
2024/02/21 20:24:34 INFO     ln -s -f libxcrypt.pc libcrypt.pc
2024/02/21 20:24:34 INFO make[2]: Leaving directory '/home/build'
2024/02/21 20:24:34 INFO make[1]: Leaving directory '/home/build'
2024/02/21 20:24:34 INFO make: Leaving directory '/home/build'
2024/02/21 20:24:34 INFO executing: bwrap --bind /tmp/melange-guest-4074152788 / --bind /tmp/melange-workspace-66114320 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv GOPATH /home/build/.cache/go --setenv GOTOOLCHAIN local --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv HOME /home/build --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv SOURCE_DATE_EPOCH 0 --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv GOFLAGS  --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
find /home/build/melange-out/libxcrypt -name '*.la' -print -exec rm \{} \;

exit 0
2024/02/21 20:24:34 INFO /home/build/melange-out/libxcrypt/usr/lib/libcrypt.la
2024/02/21 20:24:34 INFO running step "strip"
2024/02/21 20:24:34 INFO running step "Strip binaries"
2024/02/21 20:24:34 INFO executing: bwrap --bind /tmp/melange-guest-4074152788 / --bind /tmp/melange-workspace-66114320 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap --setenv HOME /home/build --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv SOURCE_DATE_EPOCH 0 --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv GOFLAGS  --setenv GOPATH /home/build/.cache/go --setenv GOTOOLCHAIN local --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build/melange-out/libxcrypt' ] || mkdir -p '/home/build/melange-out/libxcrypt'
cd '/home/build/melange-out/libxcrypt'
scanelf --recursive --nobanner --osabi --etype "ET_DYN,ET_EXEC" . \
  | while read type osabi filename; do

  [ "$osabi" != "STANDALONE" ] || continue
  # scanelf may have picked up a temp file so verify that file still exists
  strip -g "${filename}" || [ ! -e "$filename" ]
done

exit 0
2024/02/21 20:24:34 INFO running pipeline for subpackage libxcrypt-doc
2024/02/21 20:24:34 INFO running step "split/manpages"
2024/02/21 20:24:34 INFO running step "Split manpages"
2024/02/21 20:24:34 INFO evaluating if-conditional '${{targets.destdir}} != ${{targets.contextdir}}' --> true
2024/02/21 20:24:34 INFO executing: bwrap --bind /tmp/melange-guest-4074152788 / --bind /tmp/melange-workspace-66114320 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap --setenv HOME /home/build --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv SOURCE_DATE_EPOCH 0 --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv GOFLAGS  --setenv GOPATH /home/build/.cache/go --setenv GOTOOLCHAIN local --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
if [ -d "/home/build/melange-out/libxcrypt/usr/share/man" ]; then
  mkdir -p "/home/build/melange-out/libxcrypt-doc/usr/share"
  mv "/home/build/melange-out/libxcrypt/usr/share/man" "/home/build/melange-out/libxcrypt-doc/usr/share"
fi

exit 0
2024/02/21 20:24:34 INFO running pipeline for subpackage libxcrypt-dev
2024/02/21 20:24:34 INFO running step "split/dev"
2024/02/21 20:24:34 INFO running step "Split development files"
2024/02/21 20:24:34 INFO evaluating if-conditional '${{targets.destdir}} != ${{targets.contextdir}}' --> true
2024/02/21 20:24:34 INFO executing: bwrap --bind /tmp/melange-guest-4074152788 / --bind /tmp/melange-workspace-66114320 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv SOURCE_DATE_EPOCH 0 --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv GOFLAGS  --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap --setenv HOME /home/build --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv GOPATH /home/build/.cache/go --setenv GOTOOLCHAIN local --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
i= j=
cd "/home/build/melange-out/libxcrypt" || exit 0

libdirs=usr/
[ -d lib/ ] && libdirs="lib/ $libdirs"
for i in usr/include usr/lib/pkgconfig usr/share/pkgconfig \
  usr/share/aclocal usr/share/gettext \
  usr/bin/*-config usr/bin/*_config usr/share/vala/vapi \
  usr/share/gir-[0-9]* usr/share/qt*/mkspecs \
  usr/lib/qt*/mkspecs usr/lib/cmake \
  usr/lib/glade/modules usr/share/glade/catalogs \
  $(find . -name include -type d) \
  $(find $libdirs -name '*.a' 2>/dev/null) \
  $(find $libdirs -name '*.[cho]' \
    -o -name '*.prl' 2>/dev/null); do
      if [ -e "/home/build/melange-out/libxcrypt/$i" ] || [ -L "/home/build/melange-out/libxcrypt/$i" ]; then
        d="/home/build/melange-out/libxcrypt-dev/${i%/*}" # dirname $i
        mkdir -p "$d"
        mv "/home/build/melange-out/libxcrypt/$i" "$d"
        rmdir "/home/build/melange-out/libxcrypt/${i%/*}" 2>/dev/null || :
      fi
  done

  # move *.so links needed when linking the apps to -dev packages
  for i in lib/*.so usr/lib/*.so; do
    if [ -L "$i" ]; then
      mkdir -p "/home/build/melange-out/libxcrypt-dev"/"${i%/*}"
      mv "$i" "/home/build/melange-out/libxcrypt-dev/$i" || return 1
    fi
  done

exit 0
2024/02/21 20:24:34 INFO retrieving workspace from builder: 
2024/02/21 20:24:34 INFO retrieved and wrote post-build workspace to: /tmp/melange-workspace-66114320
2024/02/21 20:24:34 INFO running package linters for libxcrypt
2024/02/21 20:24:34 INFO running package linters for libxcrypt-doc
2024/02/21 20:24:34 INFO running package linters for libxcrypt-dev
2024/02/21 20:24:34 INFO generating SBOM for subpackage libxcrypt-doc
2024/02/21 20:24:34 INFO generating SBOM for subpackage libxcrypt-dev
2024/02/21 20:24:34 INFO generating package libxcrypt-4.4.36-r0
2024/02/21 20:24:34 INFO scanning for shared object dependencies...
2024/02/21 20:24:34 INFO   found soname libcrypt.so.1 for usr/lib/libcrypt.so.1
2024/02/21 20:24:34 INFO   found lib libc.so.6 for usr/lib/libcrypt.so.1.1.0
2024/02/21 20:24:34 INFO   found soname libcrypt.so.1 for usr/lib/libowcrypt.so.1
2024/02/21 20:24:34 INFO scanning for commands...
2024/02/21 20:24:34 INFO scanning for pkg-config data...
2024/02/21 20:24:34 INFO scanning for python modules...
2024/02/21 20:24:34 INFO   runtime:
2024/02/21 20:24:34 INFO     so:libc.so.6
2024/02/21 20:24:34 INFO   provides:
2024/02/21 20:24:34 INFO     so:libcrypt.so.1=1
2024/02/21 20:24:34 INFO   installed-size: 249146
2024/02/21 20:24:34 INFO   data.tar.gz digest: 0aa99919c33bd06b72d4664c292fda2b8b1b6134f6f91a2193477f981c55d72d
2024/02/21 20:24:35 INFO wrote packages/x86_64/libxcrypt-4.4.36-r0.apk
2024/02/21 20:24:35 INFO generating package libxcrypt-doc-4.4.36-r0
2024/02/21 20:24:35 INFO scanning for shared object dependencies...
2024/02/21 20:24:35 INFO scanning for commands...
2024/02/21 20:24:35 INFO scanning for pkg-config data...
2024/02/21 20:24:35 INFO scanning for python modules...
2024/02/21 20:24:35 INFO   installed-size: 84194
2024/02/21 20:24:35 INFO   data.tar.gz digest: 3d44c8a252a4708e2f421eb6428d65f71009520bb3a5eac0ca64f71afa1c1825
2024/02/21 20:24:35 INFO wrote packages/x86_64/libxcrypt-doc-4.4.36-r0.apk
2024/02/21 20:24:35 INFO generating package libxcrypt-dev-4.4.36-r0
2024/02/21 20:24:35 INFO scanning for shared object dependencies...
2024/02/21 20:24:35 INFO   found soname libcrypt.so.1 for usr/lib/libcrypt.so
2024/02/21 20:24:35 INFO scanning for commands...
2024/02/21 20:24:35 INFO scanning for pkg-config data...
2024/02/21 20:24:35 INFO   found pkg-config libxcrypt for usr/lib/pkgconfig/libxcrypt.pc
2024/02/21 20:24:35 INFO scanning for python modules...
2024/02/21 20:24:35 INFO   runtime:
2024/02/21 20:24:35 INFO     so:libcrypt.so.1
2024/02/21 20:24:35 INFO   provides:
2024/02/21 20:24:35 INFO     pc:libxcrypt=4.4.36
2024/02/21 20:24:35 INFO   installed-size: 331189
2024/02/21 20:24:35 INFO   data.tar.gz digest: f4b14883c4c39bb090dc0757a35b318b91500c9cb5d20baee19f7890ba9c1c18
2024/02/21 20:24:35 INFO wrote packages/x86_64/libxcrypt-dev-4.4.36-r0.apk
2024/02/21 20:24:35 INFO generating apk index from packages in packages/x86_64
2024/02/21 20:24:35 INFO processing package packages/x86_64/libxcrypt-dev-4.4.36-r0.apk
2024/02/21 20:24:35 INFO processing package packages/x86_64/libxcrypt-4.4.36-r0.apk
2024/02/21 20:24:35 INFO processing package packages/x86_64/libxcrypt-doc-4.4.36-r0.apk
2024/02/21 20:24:35 INFO updating index at packages/x86_64/APKINDEX.tar.gz with new packages: [libxcrypt-4.4.36-r0 libxcrypt-doc-4.4.36-r0 libxcrypt-dev-4.4.36-r0]
2024/02/21 20:24:35 INFO signing apk index at packages/x86_64/APKINDEX.tar.gz
2024/02/21 20:24:35 INFO signing index packages/x86_64/APKINDEX.tar.gz with key local-melange.rsa
2024/02/21 20:24:35 INFO appending signature to index packages/x86_64/APKINDEX.tar.gz
2024/02/21 20:24:35 INFO writing signed index to packages/x86_64/APKINDEX.tar.gz
2024/02/21 20:24:35 INFO signed index packages/x86_64/APKINDEX.tar.gz with key local-melange.rsa
make[1]: Leaving directory '/work/work'
```